### PR TITLE
Implement Moore–Hodgson scheduling algorithm

### DIFF
--- a/ResourceOptimization/ResourceOptimization.Scheduling/MinimizingNumberOfLateJobs.cs
+++ b/ResourceOptimization/ResourceOptimization.Scheduling/MinimizingNumberOfLateJobs.cs
@@ -1,0 +1,60 @@
+using DataStructures.Heaps;
+
+namespace ResourceOptimization.Scheduling;
+
+/// <summary>
+/// Implements the Moore–Hodgson algorithm to minimize the number of late jobs
+/// on a single machine. Jobs are processed in nondecreasing order of deadline.
+/// Whenever the running time exceeds the current job's deadline, the algorithm
+/// greedily drops the job with the largest processing time seen so far. A
+/// max-heap keyed by job duration allows finding this job in O(log n) time.
+/// The overall complexity is therefore O(n log n).
+///
+/// This approach is useful in settings such as production lines or other
+/// single-machine environments where each late job incurs a significant
+/// penalty and the goal is to complete as many jobs on time as possible.
+/// </summary>
+public static class MinimizingNumberOfLateJobs
+{
+    /// <summary>
+    /// Returns a schedule splitting jobs into those that can be completed
+    /// on time and those that must be rejected as late.
+    /// </summary>
+    /// <param name="jobs">List of jobs with processing durations and deadlines.</param>
+    /// <returns>Tuple of on-time jobs followed by late jobs.</returns>
+    public static (List<Job> OnTimeJobs, List<Job> LateJobs) Schedule(List<Job> jobs)
+    {
+        if (jobs.Count is 0)
+            return ([], []);
+
+        // Step 1: sort jobs by nondecreasing deadline
+        var sortedByDeadline = jobs.OrderBy(j => j.Deadline).ToList();
+
+        // Step 2: iterate through jobs maintaining current time
+        // and a max-heap keyed by duration to remove the longest job
+        var maxHeap = new HeapMax<int, Job>();
+        int currentTime = 0;
+        var lateJobs = new List<Job>();
+
+        foreach (var job in sortedByDeadline)
+        {
+            currentTime += job.Duration;
+            maxHeap.Insert(job.Duration, job);
+
+            // If deadline violated, drop the longest job so far
+            if (currentTime > job.Deadline)
+            {
+                var removed = maxHeap.ExtractNode();
+                currentTime -= removed.Key;
+                lateJobs.Add(removed.Value!);
+            }
+        }
+
+        // Jobs remaining in the heap are exactly those finished on time
+        var lateSet = lateJobs.ToHashSet();
+        var onTimeJobs = sortedByDeadline.Where(j => !lateSet.Contains(j)).ToList();
+
+        return (onTimeJobs, lateJobs);
+    }
+}
+

--- a/ResourceOptimization/ResourceOptimization.Tests/Scheduling/MinimizingNumberOfLateJobsShould.cs
+++ b/ResourceOptimization/ResourceOptimization.Tests/Scheduling/MinimizingNumberOfLateJobsShould.cs
@@ -1,0 +1,66 @@
+using ResourceOptimization.Scheduling;
+
+namespace ResourceOptimization.Tests.Scheduling;
+
+public class MinimizingNumberOfLateJobsShould
+{
+    [Fact]
+    public void Schedule_WhenNoJobs_ReturnsEmptyLists()
+    {
+        // Arrange
+        var jobs = new List<Job>();
+
+        // Act
+        var (onTime, late) = MinimizingNumberOfLateJobs.Schedule(jobs);
+
+        // Assert
+        onTime.Should().BeEmpty();
+        late.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Schedule_WhenAllJobsFit_ReturnsAllOnTime()
+    {
+        // Arrange
+        var jobs = new List<Job>
+        {
+            new(1, 1, 2),
+            new(2, 1, 3),
+            new(3, 1, 4)
+        };
+
+        // Act
+        var (onTime, late) = MinimizingNumberOfLateJobs.Schedule(jobs);
+
+        // Assert
+        onTime.Should().BeEquivalentTo(jobs.OrderBy(j => j.Deadline));
+        late.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Schedule_WhenSomeJobsLate_SplitsCorrectly()
+    {
+        // Arrange
+        var jobs = new List<Job>
+        {
+            new(1, 3, 4),
+            new(2, 5, 5),
+            new(3, 2, 6)
+        };
+
+        // Act
+        var (onTime, late) = MinimizingNumberOfLateJobs.Schedule(jobs);
+
+        // Assert
+        onTime.Should().BeEquivalentTo(new List<Job>
+        {
+            new(1, 3, 4),
+            new(3, 2, 6)
+        });
+        late.Should().BeEquivalentTo(new List<Job>
+        {
+            new(2, 5, 5)
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement the Moore–Hodgson greedy algorithm to minimize late jobs
- document algorithm details and usage
- add unit tests for empty input, all jobs on-time, and cases with late jobs

## Testing
- `dotnet test` *(fails: could not restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_685a4e07cc748328a549f6e6029b9817